### PR TITLE
Fix off-by-one in str_right

### DIFF
--- a/str.c
+++ b/str.c
@@ -82,7 +82,7 @@ str_t* str_right(const str_t* lhs, uint16_t len) {
     str_t* str = str_new(len);
     memcpy(
         str->data,
-        (lhs->data + (lhs->len - 1)) - len,
+        (lhs->data + lhs->len) - len,
         len);
     str->pos = len;
     return str;


### PR DESCRIPTION
Hi, Jeff, just watched your introductory video in your C Kong series on YouTube. Being new to C, I really enjoyed the content. I was puzzled by the off-by-one error regarding the `str_right` function and realized that actually there was no error. We were simply misled by the newline in `"HELLO WORLD!\n"`.